### PR TITLE
updating docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.5-alpine3.14 as base
+FROM python:3.9.25-alpine3.22 as base
 
 FROM base as pip_builder
 RUN apk add --no-cache gcc musl-dev libffi-dev openssl-dev openldap-dev g++ postgresql-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,10 +20,9 @@ psycopg2-binary==2.8.6
 pyaml==20.4.0
 pyjwt==2.4.0
 pytest==6.2.4
-python-ldap==3.4.0
+python-ldap==3.4.5
 python-socketio==5.3.0
 requests==2.26.0
-socketio==0.2.1
 Flask-Caching==2.1.0
 werkzeug==2.3.8
 python-dotenv==1.0.1


### PR DESCRIPTION
When I updated the image to `3.9.25-alpine3.22`, I started to face problems to build python-ldap and netiface (a dependency of socketio). The first one was resolved updating to v3.4.5. The second was more complicated, but searching on web, I found several comments that the package python-socketio (already in requirements) was a better package to install instead of socketio. In my tests, this configuration worked. 